### PR TITLE
Add special Suez ship transportation to Mamluk mission tree

### DIFF
--- a/common/custom_gui/btc_suez.txt
+++ b/common/custom_gui/btc_suez.txt
@@ -1,0 +1,66 @@
+custom_button = {
+    name = btc_enable_move_ships
+    potential = {
+		FROM = {
+			has_country_flag = btc_unlocked_suez_transportation
+		}
+
+		OR = {
+			province_id = 4316
+			province_id = 2315
+		}
+
+        NOT = {
+            has_province_flag = btc_move_ships
+        }
+    }
+    trigger = {
+		hidden_trigger = {
+			NOT = {
+				has_province_flag = btc_move_ships
+			}
+		}
+
+		4316 = {
+			owned_by = FROM
+			controlled_by = FROM
+		}
+		2315 = {
+			owned_by = ROOT
+			controlled_by = ROOT
+		}
+    }
+    effect = {
+		set_province_flag = btc_move_ships
+
+		hidden_effect = {
+			add_province_triggered_modifier = btc_move_next_ship
+		}
+    }
+    tooltip = btc_enable_move_ships_title
+}
+
+custom_button = {
+    name = btc_disable_move_ships
+    potential = {
+		FROM = {
+			has_country_flag = btc_unlocked_suez_transportation
+		}
+
+		OR = {
+			province_id = 4316
+			province_id = 2315
+		}
+		
+		has_province_flag = btc_move_ships
+    }
+    trigger = {
+		hidden_trigger = {
+			has_province_flag = btc_move_ships
+		}
+    }
+    effect = {
+        clr_province_flag = btc_move_ships
+    }
+    tooltip = btc_disable_move_ships_title
+}

--- a/common/province_triggered_modifiers/btc_suez.txt
+++ b/common/province_triggered_modifiers/btc_suez.txt
@@ -1,0 +1,135 @@
+btc_move_next_ship = {
+	#hidden = yes
+
+	potential = {
+		always = yes
+	}
+
+	trigger = {
+		always = yes
+	}
+
+	on_activation = {
+		remove_province_triggered_modifier = btc_move_next_ship
+
+		if = {
+			limit = {
+				heavy_ships_in_province = ROOT
+			}
+	
+			random_list = {
+				1 = {
+					province_event = {
+						id = btc_mam_suez.1
+						days = 5
+					}
+				}
+				1 = {
+					province_event = {
+						id = btc_mam_suez.1
+						days = 6
+					}
+				}
+				1 = {
+					province_event = {
+						id = btc_mam_suez.1
+						days = 7
+					}
+				}
+			}
+		}
+	
+		else_if = {
+			limit = {
+				light_ships_in_province = ROOT
+			}
+	
+			random_list = {
+				1 = {
+					province_event = {
+						id = btc_mam_suez.1
+						days = 4
+					}
+				}
+				1 = {
+					province_event = {
+						id = btc_mam_suez.1
+						days = 5
+					}
+				}
+				1 = {
+					province_event = {
+						id = btc_mam_suez.1
+						days = 6
+					}
+				}
+				1 = {
+					province_event = {
+						id = btc_mam_suez.1
+						days = 7
+					}
+				}
+			}
+		}
+	
+		else_if = {
+			limit = {
+				galleys_in_province = ROOT
+			}
+	
+			random_list = {
+				1 = {
+					province_event = {
+						id = btc_mam_suez.1
+						days = 3
+					}
+				}
+				1 = {
+					province_event = {
+						id = btc_mam_suez.1
+						days = 4
+					}
+				}
+				1 = {
+					province_event = {
+						id = btc_mam_suez.1
+						days = 5
+					}
+				}
+				1 = {
+					province_event = {
+						id = btc_mam_suez.1
+						days = 6
+					}
+				}
+			}
+		}
+	
+		else_if = {
+			limit = {
+				transports_in_province = ROOT
+			}
+	
+			random_list = {
+				1 = {
+					province_event = {
+						id = btc_mam_suez.1
+						days = 3
+					}
+				}
+				1 = {
+					province_event = {
+						id = btc_mam_suez.1
+						days = 4
+					}
+				}
+				1 = {
+					province_event = {
+						id = btc_mam_suez.1
+						days = 5
+					}
+				}
+			}
+		}
+	}
+}

--- a/common/scripted_effects/btc_scripted_effects_suez.txt
+++ b/common/scripted_effects/btc_scripted_effects_suez.txt
@@ -1,0 +1,114 @@
+btc_move_ship = {
+	if = {
+		limit = {
+			heavy_ships_in_province = ROOT
+		}
+
+		$from$ = {
+			kill_units = {
+				who = owner
+				type = heavy_ship
+				amount = 1
+			}
+		}
+		$to$ = {
+			heavy_ship = ROOT
+		}
+
+		owner = {
+			add_treasury = -2
+		}
+	}
+
+	else_if = {
+		limit = {
+			light_ships_in_province = ROOT
+		}
+
+		$from$ = {
+			kill_units = {
+				who = owner
+				type = light_ship
+				amount = 1
+			}
+		}
+		$to$ = {
+			light_ship = ROOT
+		}
+
+		owner = {
+			add_treasury = -1
+		}
+	}
+
+	else_if = {
+		limit = {
+			galleys_in_province = ROOT
+		}
+
+		$from$ = {
+			kill_units = {
+				who = owner
+				type = galley
+				amount = 1
+			}
+		}
+		$to$ = {
+			galley = ROOT
+		}
+
+		owner = {
+			add_treasury = -1
+		}
+	}
+
+	else_if = {
+		limit = {
+			transports_in_province = ROOT
+		}
+
+		$from$ = {
+			kill_units = {
+				who = owner
+				type = transport
+				amount = 1
+			}
+		}
+		$to$ = {
+			transport = ROOT
+		}
+
+		owner = {
+			add_treasury = -1
+		}
+	}
+
+
+	if = {
+		limit = {
+			NOT = {
+				AND = {
+					$from$ = {
+						owned_by = FROM
+						controlled_by = FROM
+					}
+					$to$ = {
+						owned_by = ROOT
+						controlled_by = ROOT
+					}
+				}
+			}
+		}
+
+		$from$ = {
+			clr_province_flag = btc_move_ships
+		}
+		$to$ = {
+			clr_province_flag = btc_move_ships
+		}
+	}
+
+	$from$ = {
+		add_province_triggered_modifier = btc_move_next_ship
+	}
+}

--- a/events/btc_MAM_suez.txt
+++ b/events/btc_MAM_suez.txt
@@ -1,0 +1,129 @@
+namespace = btc_mam_suez
+
+province_event = {
+	id = btc_mam_suez.1
+
+	title = ""
+	desc = ""
+	picture = BIG_BOOK_eventPicture
+
+	hidden = yes
+	is_triggered_only = yes
+
+	option = {
+		if = {
+			limit = {
+				province_id = 4316
+			}
+
+			province_event = {
+				id = btc_mam_suez.2
+			}
+		}
+
+		if = {
+			limit = {
+				province_id = 2315
+			}
+
+			province_event = {
+				id = btc_mam_suez.3
+			}
+		}
+	}
+}
+
+## Sharqiya -> as-Suways
+province_event = {
+	id = btc_mam_suez.2
+	
+	title = ""
+	desc = ""
+	picture = BIG_BOOK_eventPicture
+
+	hidden = yes
+	is_triggered_only = yes
+
+	trigger = {
+		province_id = 4316
+		controlled_by = ROOT
+
+		2315 = {
+			owned_by = ROOT
+			controlled_by = ROOT
+		}
+
+		owner = {
+			has_country_flag = btc_unlocked_suez_transportation
+		}
+
+		has_province_flag = btc_move_ships
+
+		OR = {
+			heavy_ships_in_province = ROOT
+			light_ships_in_province = ROOT
+			galleys_in_province = ROOT
+			transports_in_province = ROOT
+		}
+	}
+
+	option = {
+		name = ""
+        ai_chance = {
+            factor = 1
+        }
+
+		btc_move_ship = {
+			from = 4316
+			to = 2315
+		}
+	}
+}
+
+
+## Sharqiya <- as-Suways
+province_event = {
+	id = btc_mam_suez.3
+	
+	title = ""
+	desc = ""
+	picture = BIG_BOOK_eventPicture
+
+	hidden = yes
+	is_triggered_only = yes
+
+	trigger = {
+		province_id = 2315
+		controlled_by = ROOT
+
+		4316 = {
+			owned_by = ROOT
+			controlled_by = ROOT
+		}
+
+		owner = {
+			has_country_flag = btc_unlocked_suez_transportation
+		}
+
+		has_province_flag = btc_move_ships
+
+		OR = {
+			heavy_ships_in_province = ROOT
+			light_ships_in_province = ROOT
+			galleys_in_province = ROOT
+			transports_in_province = ROOT
+		}
+	}
+
+	option = {
+		name = ""
+        ai_chance = {
+            factor = 1
+        }
+
+		btc_move_ship = {
+			from = 2315
+			to = 4316
+		}
+	}
+}

--- a/interface/provinceview.gui
+++ b/interface/provinceview.gui
@@ -990,6 +990,20 @@ guiTypes = {
 				scripted = yes
 			}		
 
+			guiButtonType = {
+				name = "btc_enable_move_ships"
+				quadTextureSprite = "GFX_feitoria_button"
+				position = { x = 140 y = 328 }
+				scripted = yes
+			}	
+
+			guiButtonType = {
+				name = "btc_disable_move_ships"
+				quadTextureSprite = "GFX_fortified_feitoria_button"
+				position = { x = 140 y = 328 }
+				scripted = yes
+			}	
+
 			### CLAIMS
 			instantTextBoxType = {
 				name = "claims_title"

--- a/localisation/btc_mam_suez_l_english.yml
+++ b/localisation/btc_mam_suez_l_english.yml
@@ -1,0 +1,4 @@
+﻿l_english:
+
+ btc_enable_move_ships_title:0 "Start moving ships"
+ btc_disable_move_ships_title:0 "Stop moving ships"

--- a/missions/KoK_Mamluks_Missions.txt
+++ b/missions/KoK_Mamluks_Missions.txt
@@ -774,25 +774,26 @@ mam_missions_2 = {
 			is_at_war = no			
 		}
 		effect = {
-			if = {
-				limit = { 
-					has_dlc = "Leviathan" 
-					4316 = {
-						NOT = {
-							has_great_project = { 
-								type = suez_canal 
-								tier = 3 
-							}
-						}
-					}
-					NOT = { adm_tech = 22 }
-				}
-				country_event = { id = flavor_mam.115 }
-				custom_tooltip = flavor_mam.115_tt
-			}
-			else = {
-				4316 = { add_base_production = 3 }
-			}
+			# if = {
+			# 	limit = { 
+			# 		has_dlc = "Leviathan" 
+			# 		4316 = {
+			# 			NOT = {
+			# 				has_great_project = { 
+			# 					type = suez_canal 
+			# 					tier = 3 
+			# 				}
+			# 			}
+			# 		}
+			# 		NOT = { adm_tech = 22 }
+			# 	}
+			# 	country_event = { id = flavor_mam.115 }
+			# 	custom_tooltip = flavor_mam.115_tt
+			# }
+			# else = {
+			# 	4316 = { add_base_production = 3 }
+			# }
+			add_country_flag = btc_unlocked_suez_transportation
 			add_mercantilism = 3
 		}
 	}


### PR DESCRIPTION
- Adds a special button that allows to move ships from the mediterrenean to the red sea and back
- Unlock this button in the Mamlukean mission tree instead of an early suez canal